### PR TITLE
Check that emitter is not disposed to avoid unhandled UndeliverableException

### DIFF
--- a/app/src/main/java/me/cyber/nukleos/api/RetrofitApi.kt
+++ b/app/src/main/java/me/cyber/nukleos/api/RetrofitApi.kt
@@ -39,7 +39,7 @@ class RetrofitApi(private val mUrl: String) {
                 .subscribe({
                     emitter.onSuccess(it)
                 }, {
-                    emitter.onError(it)
+                    emitter.tryOnError(it)
                 })
     }
 
@@ -50,7 +50,7 @@ class RetrofitApi(private val mUrl: String) {
                 .subscribe({
                     emitter.onSuccess(it)
                 }, {
-                    emitter.onError(it)
+                    emitter.tryOnError(it)
                 })
     }
 
@@ -61,7 +61,7 @@ class RetrofitApi(private val mUrl: String) {
                 .subscribe({
                     emitter.onSuccess(it)
                 }, {
-                    emitter.onError(it)
+                    emitter.tryOnError(it)
                 })
     }
 
@@ -72,7 +72,7 @@ class RetrofitApi(private val mUrl: String) {
                 .subscribe({
                     emitter.onSuccess(it)
                 }, {
-                    emitter.onError(it)
+                    emitter.tryOnError(it)
                 })
     }
 

--- a/app/src/main/java/me/cyber/nukleos/bluetooth/BluetoothConnector.kt
+++ b/app/src/main/java/me/cyber/nukleos/bluetooth/BluetoothConnector.kt
@@ -72,7 +72,7 @@ class BluetoothConnector(val context: Context) {
 
         override fun onScanFailed(errorCode: Int) {
             super.onScanFailed(errorCode)
-            emitter.onError(RuntimeException())
+            emitter.tryOnError(RuntimeException())
         }
     }
 }


### PR DESCRIPTION
ChartsPresenter cancels  all subscriptions on destroy. Any error that will be received after this termination will cause UndeliverableException.
https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling
We can also set custom error handler to avoid problems with UndeliverableException in the future